### PR TITLE
Add rules for Diamond (blastp) and Prodigal

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -19,7 +19,7 @@ focal = get_ids_from_path_pattern('dataset/*')
 
 rule all:
     input:
-        expand(f'{config["path"]["root"]}/{config["folder"]["qfiltered"]}/{{IDs}}/{{IDs}}_R1.fastq.gz', IDs=IDs)
+        expand(config["path"]["root"]+"/"+config["folder"]["maxbin"]+"/{IDs}/{IDs}.maxbin-bins", IDs = IDs)
     message:
         """
         WARNING: Be very careful when adding/removing any lines above this message.
@@ -875,6 +875,12 @@ rule maxbinCross:
         mv * $(dirname {output})
         """
 
+rule binning:
+    input:
+        concoct = expand(config["path"]["root"]+"/"+config["folder"]["concoct"]+"/{IDs}/{IDs}.concoct-bins", IDs = IDs),
+        maxbin = expand(config["path"]["root"]+"/"+config["folder"]["maxbin"]+"/{IDs}/{IDs}.maxbin-bins", IDs = IDs),
+        metabat = expand(config["path"]["root"]+"/"+config["folder"]["metabat"]+"/{IDs}/{IDs}.metabat-bins", IDs = IDs)
+
 
 rule binRefine:
     input:
@@ -974,6 +980,11 @@ rule binReassemble:
         # Move results to output folder
         mv * $(dirname {output})
         """
+
+rule binEvaluation:
+    input: 
+        refined = expand(config["path"]["root"]+"/"+config["folder"]["refined"]+"/{IDs}", IDs = IDs),
+        reassembled = expand(config["path"]["root"]+"/"+config["folder"]["reassembled"]+"/{IDs}", IDs = IDs)
 
 
 rule binningVis:
@@ -1791,3 +1802,29 @@ rule roary:
 
         mv yes_al/* {output}
         """
+
+rule run_prodigal:
+    """Use Prodigal for coding genes predictions in contigs."""
+    input:
+        f'{config["path"]["root"]}/{config["folder"]["assemblies"]}/{{IDs}}/contigs.fasta.gz'
+    output:
+        gff = f'{config["path"]["root"]}/{config["folder"]["prodigal"]}/{{IDs}}/{{IDs}}_genes.gff',
+        faa = f'{config["path"]["root"]}/{config["folder"]["prodigal"]}/{{IDs}}/{{IDs}}_genes_prot.fa',
+        fna = f'{config["path"]["root"]}/{config["folder"]["prodigal"]}/{{IDs}}/{{IDs}}_genes_nucl.fa',
+        log = f'{config["path"]["root"]}/{config["folder"]["prodigal"]}/{{IDs}}/{{IDs}}_log.out'
+    shell:
+        """
+        mkdir -p $(dirname {output.gff})
+        prodigal -i <(gunzip -c {input}) -o {output.gff} -a {output.faa} -d {output.fna} -p meta  &> {output.log}
+        """
+
+rule run_blastp:
+    """Use Diamond blastp for searching against coding genes predictions from contigs. Uses snakemake wrapper: https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/diamond/blastp.html"""
+    input:
+        fname_fasta=f'{config["path"]["root"]}/{config["folder"]["prodigal"]}/{{IDs}}/{{IDs}}_genes_prot.fa',
+        fname_db=f'{config["path"]["root"]}/{config["folder"]["blastp_db"]}'
+    output:
+        fname=f'{config["path"]["root"]}/{config["folder"]["blastp"]}/{{IDs}}.xml'
+    threads: 8
+    wrapper:
+        "https://github.com/snakemake/snakemake-wrappers/raw/0.80.1/bio/diamond/blastp"

--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,9 @@ folder:
     kallisto: kallisto
     kallistoIndex: kallistoIndex
     benchmarks: benchmarks
+    prodigal: prodigal
+    blastp: blastp
+    blastp_db: 
 scripts:
     kallisto2concoct: kallisto2concoct.py
     prepRoary: prepareRoaryInput.R
@@ -57,6 +60,7 @@ cores:
     grid: 24
     prokka: 2
     roary: 12
+    diamond: 12
 params:
     cutfasta: 10000
     assemblyPreset: meta-sensitive

--- a/metaGEM.sh
+++ b/metaGEM.sh
@@ -460,7 +460,7 @@ parse() {
   sed  -i "2s~/.*$~$root~" config.yaml # hardcoded line for root, change the number 2 if any new lines are added to the start of config.yaml
 
   # No need to parse snakefile for login node jobs, submit the following locally
-  if [ $task == "createFolders" ] || [ $task == "downloadToy" ] || [ $task == "organizeData" ] || [ $task == "qfilterVis" ] || [ $task == "assemblyVis" ] || [ $task == "binningVis" ] || [ $task == "compositionVis" ] || [ $task == "abundanceVis" ] || [ $task == "extractProteinBins" ] || [ $task == "extractDnaBins" ] || [ $task == "organizeGEMs" ] || [ $task == "modelVis" ] || [ $task == "interactionVis" ] || [ $task == "growthVis" ] || [ $task == "prepareRoary" ]; then
+  if [ $task == "createFolders" ] || [ $task == "downloadToy" ] || [ $task == "organizeData" ] || [ $task == "qfilterVis" ] || [ $task == "assemblyVis" ] || [ $task == "binningVis" ] || [ $task == "compositionVis" ] || [ $task == "abundanceVis" ] || [ $task == "extractProteinBins" ] || [ $task == "extractDnaBins" ] || [ $task == "organizeGEMs" ] || [ $task == "modelVis" ] || [ $task == "interactionVis" ] || [ $task == "growthVis" ] || [ $task == "binning" ] || [ $task == "binEvaluation" ] || [ $task == "prepareRoary" ]; then
     submitLogin
 
   elif [ $task == "check" ]; then
@@ -502,6 +502,14 @@ parse() {
         submitCluster
     fi
 
+  elif [ $task == "kallistoIndex" ]; then
+    string='expand(config["path"]["root"]+"/"+config["folder"]["kallistoIndex"]+"/{focal}/index.kaix", focal = focal)'
+    if [ $local == "true" ]; then
+        submitLocal
+    else
+        submitCluster
+    fi
+
   elif [ $task == "crossMapParallel" ]; then
     string='expand(config["path"]["root"]+"/"+config["folder"]["kallisto"]+"/{focal}/{IDs}", focal = focal , IDs = IDs)'
     if [ $local == "true" ]; then
@@ -510,8 +518,17 @@ parse() {
         submitCluster
     fi
 
-  elif [ $task == "kallisto2concoct" ]; then
-    string='expand(config["path"]["root"]+"/"+config["folder"]["concoct"]+"/{focal}/cov/coverage_table.tsv", focal = focal)'
+  elif [ $task == "run_prodigal" ]; then
+    string='expand(config["path"]["root"]+"/"+config["folder"]["prodigal"]+"/{IDs}/{IDs}_genes.gff", IDs = IDs)'
+    if [ $local == "true" ]; then
+        submitLocal
+    else
+        submitCluster
+    fi
+
+
+  elif [ $task == "run_blastp" ]; then
+    string='expand(config["path"]["root"]+"/"+config["folder"]["blastp"]+"/{IDs}.xml", IDs = IDs)'
     if [ $local == "true" ]; then
         submitLocal
     else
@@ -536,6 +553,14 @@ parse() {
 
   elif [ $task == "maxbin" ]; then
     string='expand(config["path"]["root"]+"/"+config["folder"]["maxbin"]+"/{IDs}/{IDs}.maxbin-bins", IDs = IDs)'
+    if [ $local == "true" ]; then
+        submitLocal
+    else
+        submitCluster
+    fi
+
+  elif [ $task == "binning" ]; then
+    string='expand(config["path"]["root"]+"/"+config["folder"]["benchmarks"]+"/{IDs}/{IDs}.binning.benchmark.txt", IDs = IDs)'
     if [ $local == "true" ]; then
         submitLocal
     else


### PR DESCRIPTION
Four new rules proposed, with no new software dependencies.

1. run_prodigal - predicts ORFs on contigs rather than assembled genomes (perhaps could be renamed to contig_prodigal to avoid confusion)
2. run_blastp - takes contig ORFs as input, uses the Diamond Blastp Snakemake wrapper: https://github.com/snakemake/snakemake-wrappers/tree/0.80.1/bio/diamond/blastp
3. binning - calls the outputs from concoct, metabat, and maxbin
4. binEvaluation - calls the outputs from binRefine and binReassembly

The parsing rules for binning and binEvaluation may be iffy - I tested on a login node, rather than as a cluster job.