### PR TITLE
Suggestion: Remove temporary output of CrossMapParallel

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -356,14 +356,14 @@ rule assemblyVis:
             ID=$(echo $(basename $(dirname $assembly)))
 
             # Check if assembly file is empty
-            check=$(less $assembly|wc -l)
+            check=$(zcat $assembly | head | wc -l)
             if [ $check -eq 0 ]
             then
                 N=0
                 L=0
             else
-                N=$(less $assembly|grep -c ">");
-                L=$(less $assembly|grep ">"|cut -d '-' -f4|sed 's/len=//'|awk '{{sum+=$1}}END{{print sum}}');
+                N=$(zcat $assembly | grep -c ">");
+                L=$(zcat $assembly | grep ">"|cut -d '-' -f4|sed 's/len=//'|awk '{{sum+=$1}}END{{print sum}}');
             fi
 
             # Write values to stats file

--- a/Snakefile
+++ b/Snakefile
@@ -612,7 +612,7 @@ rule kallisto2concoctTable:
 
         # Compile individual mapping results into coverage table for given assembly
         python {config[path][root]}/{config[folder][scripts]}/{config[scripts][kallisto2concoct]} \
-            --samplenames <(for s in {input}*; do echo $s|sed 's|^.*/||'; done) \
+            --samplenames <(for s in {input}/*; do echo $s|sed 's|^.*/||'; done) \
             $(find {input} -name "*.gz") > {output}
     
         """

--- a/Snakefile
+++ b/Snakefile
@@ -581,6 +581,11 @@ rule crossMapParallel:
 
         # Move mapping file out output folder
         mv abundance.tsv.gz {output}
+
+        # Cleanup temp folder
+        echo -e "\nRemoving temporary directory {config[path][scratch]}/{config[folder][kallisto]}/${{focal}}_${{mapping}} ... "
+        cd ..
+        rm -r {config[path][scratch]}/{config[folder][kallisto]}/${{focal}}_${{mapping}}
         """
 
 rule gatherCrossMapParallel: 


### PR DESCRIPTION
CrossMapParallel creates a lot of data on the scratch drive without ever removing - or needing - it. For only 81 samples, it caused over 30TB temporal garbage.
Instead, after successful completion of the rule, the temp directories should be removed from scratch folder.