### PR TITLE
Fix an issue with metabat2

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -733,13 +733,16 @@ rule metabat:
 
         # Run metabat2
         echo -e "\nRunning metabat2 ... "
-        metabat2 -i $fsampleID.fa $id.sort -s \
+        jgi_summarize_bam_contig_depths --outputDepth $id.depth.txt $id.sort
+
+        metabat2 -i $fsampleID.fa -a $id.depth.txt -s \
             {config[params][metabatMin]} \
             -v --seed {config[params][seed]} \
             -t 0 -m {config[params][minBin]} \
             -o $(basename $(dirname {output}))
 
         rm $fsampleID.fa
+        rm $id.depth.txt
 
         # Move files to output dir
         mv *.fa {output}


### PR DESCRIPTION
In combination with the CrossMapParallel workflow, the 'rule metabat' has to be used (instead of metabatCross).
This rule failed due to a 'too many positional arguments' error in metabat2.
The current interfact of metabat2 _does not_ support to directly supply mapping files.
Instead, the mapping file is first converted to a depth file, the latter is used then directly with metabat2.