### PR TITLE
minor bugfix: maxbin Snakefile rule

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -728,7 +728,7 @@ rule maxbinCross:
 
         # Move files into output dir
         mkdir -p $(basename {output})
-        [ -f *.fasta ] && mv *.fasta $(basename {output})
+        while read bin;do mv $bin $(basename {output});done< <(ls|grep fasta)
         mv * $(dirname {output})
         """
 


### PR DESCRIPTION
maxbin was placing the resulting bins outside the expected folder, causing an error downstream during metaWRAP bin refinement. thanks to @LiZhihua1982 for reporting https://github.com/franciscozorrilla/metaGEM/issues/74#issuecomment-1336332050