### PR TITLE
feature: add support for eggnog-mapper

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1021,6 +1021,34 @@ rule binningVis:
         rm Rplots.pdf
         """
 
+rule eggnog_mapper:
+    input:
+        f'{config["path"]["root"]}/final_mags/'
+    output:
+        directory(f'{config["path"]["root"]}/emapper/')
+    benchmark:
+        f'{config["path"]["root"]}/{config["folder"]["benchmarks"]}/{{IDs}}.eggnog_mapper.benchmark.txt'
+    message:
+        """
+        batch process small number of genomes with eggnog mapper, make sure you have downloaded and 
+        configured the eggnog database path, assumes that you have ORF annotated protein fasta files 
+        (e.g. translated from DNA using prodigal) in final_mags folder, then will loop through each
+        faa file and run eggnog to produce gene annotations files, Warning: this can take a few 
+        minutes and load up to 45GB to RAM
+        """
+
+    shell:
+        """
+        # Activate eggnog environment
+        set +u;source activate eggnog6;set -u;
+
+        cd {input}
+
+        while read protein;do
+            emapper.py -m diamond -i $protein -o ${protein%.*} --cpu 18 --dbmem --excel --scratch_dir .
+        done< <(ls|grep faa)
+        """
+        
 rule abundance:
     input:
         bins = f'{config["path"]["root"]}/{config["folder"]["reassembled"]}/{{IDs}}/reassembled_bins',


### PR DESCRIPTION
🐍 Snakefile tasks

- [x] create eggnog-mapper rule for processing ORF-annotated protein fasta files of genomes
- [ ] create helper/supplementary rule to deal with large number of genomes (e.g. per sample submission of jobs)

🔨 Additional modifications for full integration/support

- [ ] metaGEM.sh: add options + support for new tasks
- [ ] config.yaml: add params used in new tasks
- [ ] config readme file: eggnog-mapper could go in main metaGEM env
- [ ] conda recipe: update
- [ ] main readme file: text and eventually figure